### PR TITLE
Include row and colnames

### DIFF
--- a/01-starting-with-data.md
+++ b/01-starting-with-data.md
@@ -256,6 +256,19 @@ head(dat)
 
 ~~~
 
+Using character vectors, we can assign identifying names to each row or column with the 'rownames' and 'colnames' commands. These are displayed with the corresponding data when called as shown below:
+
+~~~{.r}
+rownames(dat)<-paste("Row", 1:40)
+colnames(dat)<-paste("Col", 1:40)
+head (dat)
+~~~
+
+
+~~~{.output}
+Display matrix with row/col names - will have impact on downstream outputs too.
+~~~
+
 > ## Challenge {.challenge}
 >
 > Draw diagrams showing what variables refer to what values after each statement in the following program:


### PR DESCRIPTION
First submission (at SWC instructor training Melbourne) - new to git, md and Rmd

Row and Col names are incredibly useful to researchers and make it easier to understand subsets later in course. I know this will change a substantial number of outputs. Is there a way to generate the output again?

Any help or feedback on whether this is feasible or beneficial would be appreciated
